### PR TITLE
created synonym  to read patient_dim from i2b2MetaData schema (oracle)

### DIFF
--- a/edu.harvard.i2b2.data/Release_1-7/NewInstall/Metadata/scripts/procedures/oracle/pat_count_visits.sql
+++ b/edu.harvard.i2b2.data/Release_1-7/NewInstall/Metadata/scripts/procedures/oracle/pat_count_visits.sql
@@ -1,3 +1,8 @@
+-- If your i2b2MetaData schema cant read, i2b2Data schema
+-- grant select  on  "&&DataSchemaName"."PATIENT_DIMENSION" to "&&schemaName";
+create synonym PATIENT_DIMENSION for "&&DataSchemaName"."PATIENT_DIMENSION";
+
+
 create or replace PROCEDURE                 pat_count_visits  (metadataTable IN VARCHAR, schemaName IN VARCHAR, 
    errorMsg OUT VARCHAR)
 IS

--- a/edu.harvard.i2b2.data/Release_1-7/NewInstall/Metadata/scripts/procedures/oracle/pat_count_visits.sql
+++ b/edu.harvard.i2b2.data/Release_1-7/NewInstall/Metadata/scripts/procedures/oracle/pat_count_visits.sql
@@ -1,4 +1,4 @@
--- If your i2b2MetaData schema cant read, i2b2Data schema
+-- If your i2b2MetaData schema cant read i2b2Data schema
 -- grant select  on  "&&DataSchemaName"."PATIENT_DIMENSION" to "&&schemaName";
 create synonym PATIENT_DIMENSION for "&&DataSchemaName"."PATIENT_DIMENSION";
 


### PR DESCRIPTION
Hi Jeff,

Following changes needed at KUMC to run the code.

1. Created synonym for pat dim 
2. give permission metadata schema to read pat dim